### PR TITLE
Correct WIF byte marker for DARK addresses

### DIFF
--- a/arkcoin/const.go
+++ b/arkcoin/const.go
@@ -13,7 +13,7 @@ var (
 		//HDPublicKeyID:          []byte{0x04, 0x88, 0xb2, 0x1e},
 	}
 	ArkCoinDevTest = &Params{
-		DumpedPrivateKeyHeader: []byte{239}, //wif
+		DumpedPrivateKeyHeader: []byte{170}, //wif
 		AddressHeader:          30,          //0x17
 		//P2SHHeader:             5,
 		//HDPrivateKeyID:         []byte{0x04, 0x88, 0xad, 0xe4},

--- a/core/arkenv.go
+++ b/core/arkenv.go
@@ -190,10 +190,6 @@ func switchNetwork(arkNetwork ArkNetworkType) {
 	BaseURL = LoadActiveConfiguration(arkNetwork)
 	var wifHeader = []byte{170}
 
-	if arkNetwork == DEVNET {
-		wifHeader = []byte{239}
-	}
-
 	coinParams := arkcoin.Params{
 		AddressHeader:          EnvironmentParams.Network.AddressVersion,
 		DumpedPrivateKeyHeader: wifHeader,


### PR DESCRIPTION
* Updated devnet WIF byte marker to match Ark Core. 
* Removed if check for DEVNET since both dev and main net use the same WIF marker.